### PR TITLE
Adding key_suffix to redis - avoid hchecker overlap each other on resta...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 hchecker
 *.prof
 *.pyc
+src
+hipache-hchecker

--- a/Godeps
+++ b/Godeps
@@ -1,0 +1,11 @@
+{
+	"ImportPath": "github.com/morpheu/hipache-hchecker",
+	"GoVersion": "go1.2",
+	"Deps": [
+		{
+			"ImportPath": "github.com/fzzy/radix/redis",
+			"Comment": "v0.3.4",
+			"Rev": "56a3833b5d3c85770aa9b03259ecb28cdf87b837"
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ on the same machine than Hipache.
       -io=3: Socket read/write timeout (seconds)
       -method="HEAD": HTTP method
       -redis="localhost:6379": Network address of Redis
+      -redis_suffix="": Redis suffix to be appended on default hchecker key - required for multiples hchecker instances on same redis server.
       -uri="/CloudHealthCheck": HTTP URI
 
 4. Run the tests

--- a/cache.go
+++ b/cache.go
@@ -8,11 +8,11 @@ import (
 )
 
 const (
-	REDIS_PREFFIX  = "hchecker"
-	REDIS_ADDRESS  = "localhost:6379"
-	REDIS_PASSWORD = ""
+	REDIS_PREFFIX      = "hchecker"
+	REDIS_ADDRESS      = "localhost:6379"
+	REDIS_PASSWORD     = ""
 	REDIS_IDLE_TIMEOUT = 120
-	REDIS_MAX_IDLE = 3
+	REDIS_MAX_IDLE     = 3
 )
 
 var (

--- a/cache.go
+++ b/cache.go
@@ -8,16 +8,18 @@ import (
 )
 
 const (
-	REDIS_KEY      = "hchecker"
-	REDIS_ADDRESS  = "localhost:6379"
-	REDIS_PASSWORD = ""
+	REDIS_KEY          = "hchecker"
+	REDIS_ADDRESS      = "localhost:6379"
+	REDIS_PASSWORD     = ""
 	REDIS_IDLE_TIMEOUT = 120
-	REDIS_MAX_IDLE = 3
+	REDIS_MAX_IDLE     = 3
 )
 
 var (
-	redisAddress  string
-	redisPassword string
+	redisAddress     string
+	redisPassword    string
+	redisMaxIdle     int
+	redisIdleTimeout int
 )
 
 type Cache struct {
@@ -33,7 +35,7 @@ type Cache struct {
 func NewCache() (*Cache, error) {
 	pool := &redis.Pool{
 		MaxIdle:     redisMaxIdle,
-		IdleTimeout: redisIdleTimeout * time.Second,
+		IdleTimeout: time.Duration(redisIdleTimeout) * time.Second,
 		Dial: func() (redis.Conn, error) {
 			c, err := redis.Dial("tcp", redisAddress)
 			if err != nil {

--- a/cache.go
+++ b/cache.go
@@ -11,6 +11,8 @@ const (
 	REDIS_KEY      = "hchecker"
 	REDIS_ADDRESS  = "localhost:6379"
 	REDIS_PASSWORD = ""
+	REDIS_IDLE_TIMEOUT = 120
+	REDIS_MAX_IDLE = 3
 )
 
 var (
@@ -30,8 +32,8 @@ type Cache struct {
 
 func NewCache() (*Cache, error) {
 	pool := &redis.Pool{
-		MaxIdle:     3,
-		IdleTimeout: 240 * time.Second,
+		MaxIdle:     redisMaxIdle,
+		IdleTimeout: redisIdleTimeout * time.Second,
 		Dial: func() (redis.Conn, error) {
 			c, err := redis.Dial("tcp", redisAddress)
 			if err != nil {

--- a/hchecker.go
+++ b/hchecker.go
@@ -150,9 +150,9 @@ func parseFlags(cpuProfile *bool) {
 		"Network address of Redis")
 	flag.StringVar(&redisPassword, "redis_password", REDIS_PASSWORD,
 		"Password of Redis")
-	flag.StringVar(&redisIdleTimeout, "redis_idle_timeout", REDIS_IDLE_TIMEOUT,
+	flag.IntVar(&redisIdleTimeout, "redis_idle_timeout", REDIS_IDLE_TIMEOUT,
 		"Close redis connections after remaining idle for this duration (0 = no connection close)")
-	flag.StringVar(&redisMaxIdle, "redis_max_idle", REDIS_MAX_IDLE,
+	flag.IntVar(&redisMaxIdle, "redis_max_idle", REDIS_MAX_IDLE,
 		"Maximum number of idle redis connections in the pool")
 	flag.BoolVar(cpuProfile, "cpuprofile", false,
 		"Write CPU profile to \"hchecker.prof\" (current directory)")

--- a/hchecker.go
+++ b/hchecker.go
@@ -150,6 +150,10 @@ func parseFlags(cpuProfile *bool) {
 		"Network address of Redis")
 	flag.StringVar(&redisPassword, "redis_password", REDIS_PASSWORD,
 		"Password of Redis")
+	flag.StringVar(&redisIdleTimeout, "redis_idle_timeout", REDIS_IDLE_TIMEOUT,
+		"Close redis connections after remaining idle for this duration (0 = no connection close)")
+	flag.StringVar(&redisMaxIdle, "redis_max_idle", REDIS_MAX_IDLE,
+		"Maximum number of idle redis connections in the pool")
 	flag.BoolVar(cpuProfile, "cpuprofile", false,
 		"Write CPU profile to \"hchecker.prof\" (current directory)")
 	flag.BoolVar(&dryRun, "dryrun", false,

--- a/hchecker.go
+++ b/hchecker.go
@@ -148,6 +148,8 @@ func parseFlags(cpuProfile *bool) {
 		"Socket read/write timeout (seconds)")
 	flag.StringVar(&redisAddress, "redis", REDIS_ADDRESS,
 		"Network address of Redis")
+	flag.StringVar(&redisSuffix, "redis_suffix", "",
+		"Redis key suffix - use unique identifier to avoid hchecker overlap each other on restart.")
 	flag.BoolVar(cpuProfile, "cpuprofile", false,
 		"Write CPU profile to \"hchecker.prof\" (current directory)")
 	flag.BoolVar(&dryRun, "dryrun", false,


### PR DESCRIPTION
Adding suffix to hchecker redis key on each hipache-hchecker instance to avoid key overlap on instances restart/start.
